### PR TITLE
Exercises 9.1.1

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,14 +9,14 @@ class User < ApplicationRecord
   validates :password, presence: true, length: { minimum: 6 }
 
   # 渡された文字列のハッシュ値を返す
-  def User.digest(string)
+  def self.digest(string)
     cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST :
                                                   BCrypt::Engine.cost
     BCrypt::Password.create(string, cost: cost)
   end
 
   #ランダムトークンを返す
-  def User.new_token
+  def self.new_token
     SecureRandom.urlsafe_base64
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,15 +9,16 @@ class User < ApplicationRecord
   validates :password, presence: true, length: { minimum: 6 }
 
   class << self
-  # 渡された文字列のハッシュ値を返す
-  def digest(string)
-    cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST :
-                                                  BCrypt::Engine.cost
-    BCrypt::Password.create(string, cost: cost)
-  end
+    # 渡された文字列のハッシュ値を返す
+    def digest(string)
+      cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST :
+                                                    BCrypt::Engine.cost
+      BCrypt::Password.create(string, cost: cost)
+    end
 
-  #ランダムトークンを返す
-  def new_token
-    SecureRandom.urlsafe_base64
+    #ランダムトークンを返す
+    def new_token
+      SecureRandom.urlsafe_base64
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,15 +8,16 @@ class User < ApplicationRecord
   has_secure_password
   validates :password, presence: true, length: { minimum: 6 }
 
+  class << self
   # 渡された文字列のハッシュ値を返す
-  def self.digest(string)
+  def digest(string)
     cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST :
                                                   BCrypt::Engine.cost
     BCrypt::Password.create(string, cost: cost)
   end
 
   #ランダムトークンを返す
-  def self.new_token
+  def new_token
     SecureRandom.urlsafe_base64
   end
 end


### PR DESCRIPTION
リスト 9.3では、明示的にUserクラスを呼び出すことで、新しいトークンやダイジェスト用のクラスメソッドを定義しました。実際、User.new_tokenやUser.digestを使って呼び出せるようになったので、おそらく最も明確なクラスメソッドの定義方法であると言えるでしょう。 しかし実は、より「Ruby的に正しい」クラスメソッドの定義方法が２通りあります。1つはややわかりにくく、もう1つは非常に混乱するでしょう。テストスイートを実行して、リスト 9.4 (ややわかりにくい) や、リスト 9.5 (非常に混乱する) の実装でも、正しく動くことを確認してみてください。ヒント: selfは、通常の文脈ではUser「モデル」、つまりユーザーオブジェクトのインスタンスを指しますが、リスト 9.4やリスト 9.5の文脈では、selfはUser「クラス」を指すことにご注意ください。 わかりにくさの原因の一部はこの点にあります。