### PR TITLE
Exercises-10.1.3

### DIFF
--- a/test/integration/user_edit_test.rb
+++ b/test/integration/user_edit_test.rb
@@ -14,5 +14,6 @@ class UserEditTest < ActionDispatch::IntegrationTest
                                               password_confirmation: "bar" } }
 
     assert_template 'users/edit'
+    assert_select 'div.alert', 'The form contains 4 errors.'
   end
 end


### PR DESCRIPTION
リスト 10.9のテストに１行追加し、正しい数のエラーメッセージが表示されているかテストしてみてましょう。ヒント: 表 5.2で紹介したassert_selectを使ってalertクラスのdivタグを探しだし、「The form contains 4 errors.」というテキストを精査してみましょう。