### PR TITLE
Exercises-10.3.1

### DIFF
--- a/test/integration/site_layout_test.rb
+++ b/test/integration/site_layout_test.rb
@@ -17,4 +17,24 @@ class SiteLayoutTest < ActionDispatch::IntegrationTest
     get signup_path
     assert_select "title", full_title("Sign up")
   end
+
+  def setup
+    @user = users(:michael)
+  end
+
+  test "layout links when loggin" do
+    log_in_as(@user)
+    get root_path
+    assert_template 'static_pages/home'
+    assert_select "a[href=?]", root_path, count: 2
+    assert_select "a[href=?]", help_path
+    assert_select "a[href=?]", about_path
+    assert_select "a[href=?]", contact_path
+    assert_select "a[href=?]", users_path
+    assert_select "a[href=?]", user_path(@user)
+    assert_select "a[href=?]", edit_user_path(@user)
+    assert_select "a[href=?]", logout_path
+    get users_path
+    assert_select "title", full_title("All users")
+  end
 end

--- a/test/integration/site_layout_test.rb
+++ b/test/integration/site_layout_test.rb
@@ -9,6 +9,9 @@ class SiteLayoutTest < ActionDispatch::IntegrationTest
     assert_select "a[href=?]", help_path
     assert_select "a[href=?]", about_path
     assert_select "a[href=?]", contact_path
+    assert_select "a[href=?]", login_path
+    get login_path
+    assert_select "title", full_title("Log in")
     get contact_path
     assert_select "title", full_title("Contact")
     get signup_path


### PR DESCRIPTION
レイアウトにあるすべてのリンクに対して統合テストを書いてみましょう。ログイン済みユーザーとそうでないユーザーのそれぞれに対して、正しい振る舞いを考えてください。ヒント: log_in_asヘルパーを使ってリスト 5.32にテストを追加してみましょう。