### PR TITLE
ページネーションが2つ表示されることを追加

### DIFF
--- a/test/integration/users_index_test.rb
+++ b/test/integration/users_index_test.rb
@@ -10,7 +10,7 @@ class UsersIndexTest < ActionDispatch::IntegrationTest
     log_in_as(@user)
     get users_path
     assert_template 'users/index'
-    assert_select 'div.pagination'
+    assert_select 'div.pagination', count: 2
     User.paginate(page: 1).each do |user|
       assert_select 'a[href=?]', user_path(user), text: user.name
     end


### PR DESCRIPTION
先ほどは２つともコメントアウトしましたが、１つだけコメントアウトした場合、テストが greenのままであることを確認してみましょう。will_paginateのリンクが２つとも存在していることをテストしたい場合は、どのようなテストを追加すれば良いでしょうか? ヒント: 表 5.2を参考にして、数をカウントするテストを追加してみましょう。