### PR TITLE
Exercises 10.4.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,15 +15,15 @@ gem 'turbolinks',   '5.0.1'
 gem 'jbuilder',     '2.4.1'
 
 group :development, :test do
+  gem 'pry-rails'  # rails console(もしくは、rails c)でirbの代わりにpryを使われる
+  gem 'pry-doc'    # methodを表示
+  gem 'pry-byebug' # デバッグを実施(Ruby 2.0以降で動作する)
+  gem 'pry-stack_explorer' # スタックをたどれる
   gem 'sqlite3', '1.3.11'
   gem 'byebug',  '9.0.0', platform: :mri
 end
 
 group :development do
-  gem 'pry-rails'  # rails console(もしくは、rails c)でirbの代わりにpryを使われる
-  gem 'pry-doc'    # methodを表示
-  gem 'pry-byebug' # デバッグを実施(Ruby 2.0以降で動作する)
-  gem 'pry-stack_explorer' # スタックをたどれる
   gem 'web-console',           '3.1.1'
   gem 'listen',                '3.0.8'
   gem 'spring',                '1.7.2'

--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,10 @@ group :development, :test do
 end
 
 group :development do
+  gem 'pry-rails'  # rails console(もしくは、rails c)でirbの代わりにpryを使われる
+  gem 'pry-doc'    # methodを表示
+  gem 'pry-byebug' # デバッグを実施(Ruby 2.0以降で動作する)
+  gem 'pry-stack_explorer' # スタックをたどれる
   gem 'web-console',           '3.1.1'
   gem 'listen',                '3.0.8'
   gem 'spring',                '1.7.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,6 +43,8 @@ GEM
     autoprefixer-rails (6.7.7.1)
       execjs
     bcrypt (3.1.11)
+    binding_of_caller (0.7.2)
+      debug_inspector (>= 0.0.1)
     bootstrap-sass (3.3.6)
       autoprefixer-rails (>= 5.2.1)
       sass (>= 3.3.4)
@@ -121,6 +123,17 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    pry-byebug (3.4.2)
+      byebug (~> 9.0)
+      pry (~> 0.10)
+    pry-doc (0.10.0)
+      pry (~> 0.9)
+      yard (~> 0.9)
+    pry-rails (0.3.6)
+      pry (>= 0.10.4)
+    pry-stack_explorer (0.4.9.2)
+      binding_of_caller (>= 0.7)
+      pry (>= 0.9.11)
     puma (3.4.0)
     rack (2.0.1)
     rack-test (0.6.3)
@@ -196,6 +209,7 @@ GEM
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
     will_paginate (3.1.0)
+    yard (0.9.8)
 
 PLATFORMS
   ruby
@@ -214,6 +228,10 @@ DEPENDENCIES
   listen (= 3.0.8)
   minitest-reporters (= 1.1.9)
   pg (= 0.18.4)
+  pry-byebug
+  pry-doc
+  pry-rails
+  pry-stack_explorer
   puma (= 3.4.0)
   rails (= 5.0.2)
   rails-controller-testing (= 0.1.1)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -41,7 +41,7 @@ class UsersController < ApplicationController
 
   private
 
-    # ストロングパラメーター
+    # ストロングパラメーター(ホワイトリスト)
     def user_params
       params.require(:user).permit(:name, :email, :password,
                                    :password_confirmation)

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -23,6 +23,17 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to login_url
   end
 
+  test "should not allow the admin attribute to be edited via the web" do
+    log_in_as(@other_user)
+    assert_not @other_user.admin?
+
+    patch user_path(@other_user), params: {
+                                    user: { password:              "",
+                                            password_confirmation: "",
+                                            admin: true } }
+    assert_not @other_user.reload.admin?
+  end
+
   test "should redirect update when not logged in" do
     patch user_path(@user), params: { user: { name: @user.name,
                                               email: @user.email } }


### PR DESCRIPTION
Web経由でadmin属性を変更できないことを確認してみましょう。具体的には、リスト 10.56に示したように、PATCHを直接ユーザーのURL (/users/:id) に送信するテストを作成してみてください。テストが正しい振る舞いをしているかどうか確信を得るために、まずはadminをuser_paramsメソッド内の許可されたパラメータ一覧に追加するところから始めてみましょう。最初のテストの結果は redになるはずです。