### PR TITLE
Exercises11.1.2

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -45,7 +45,7 @@ class User < ApplicationRecord
 
     # メールアドレスをすべて小文字にする
     def downcase_email
-      self.email = email.downcase
+      email.downcase!
     end
 
     # 有効化トークンとダイジェストを作成および代入する


### PR DESCRIPTION
1. コンソールからUserクラスのインスタンスを生成し、そのオブジェクトからcreate_activation_digestメソッドを呼び出そうとすると (Privateメソッドなので) NoMethodErrorが発生することを確認してみましょう。また、そのUserオブジェクトからダイジェストの値も確認してみましょう。

```sh
[2] pry(main)> user = User.first
  User Load (0.2ms)  SELECT  "users".* FROM "users" ORDER BY "users"."id" ASC LIMIT ?  [["LIMIT", 1]]
=> #<User:0x007fbf676e7070
 id: 1,
 name: "Example User",
 email: "example@railstutorial.org",
 created_at: Sat, 15 Apr 2017 13:49:18 UTC +00:00,
 updated_at: Sun, 16 Apr 2017 05:23:13 UTC +00:00,
 password_digest: "$2a$10$osWIJDVjOIhKynhkONwo7.TD3KubN8mCSt.cMolTMNosKRH9knn3O",
 remember_digest: nil,
 admin: true,
 activation_digest: nil,
 activated: false,
 activated_at: nil>
[3] pry(main)> user
=> #<User:0x007fbf676e7070
 id: 1,
 name: "Example User",
 email: "example@railstutorial.org",
 created_at: Sat, 15 Apr 2017 13:49:18 UTC +00:00,
 updated_at: Sun, 16 Apr 2017 05:23:13 UTC +00:00,
 password_digest: "$2a$10$osWIJDVjOIhKynhkONwo7.TD3KubN8mCSt.cMolTMNosKRH9knn3O",
 remember_digest: nil,
 admin: true,
 activation_digest: nil,
 activated: false,
 activated_at: nil>
[4] pry(main)> user.create_activation_digest
NoMethodError: private method `create_activation_digest' called for #<User:0x007fbf676e7070>
Did you mean?  created_at_change
               created_at_previous_change
               created_at
               created_at_was
               created_at_changed?
               created_at_will_change!
               restore_activation_digest!
from /usr/local/lib/ruby/gems/2.3.0/gems/activemodel-5.0.2/lib/active_model/attribute_methods.rb:430:in `method_missing'
[5] pry(main)> user.activation_digest
=> nil
```

1. リスト 6.34で、メールアドレスの小文字化にはemail.downcase!という (代入せずに済む) メソッドがあることを知りました。このメソッドを使って、リスト 11.3のdowncase_emailメソッドを改良してみてください。また、うまく変更できれば、テストスイートは成功したままになっていることも確認してみてください。